### PR TITLE
Fix is_ability_active

### DIFF
--- a/src/inventory.c
+++ b/src/inventory.c
@@ -1758,10 +1758,10 @@ s32 is_ability_active(s32 ability) {
 
     for (i = 0; i < ARRAY_COUNT(playerData->equippedBadges); i++) {
         badgeItemID = playerData->equippedBadges[i];
+        if (badgeItemID == ITEM_NONE)
+            continue;
 
-        if (badgeItemID != ITEM_NONE) {
-            badgeMoveID = gItemTable[badgeItemID].moveID;
-        }
+        badgeMoveID = gItemTable[badgeItemID].moveID;
 
         switch (ability) {
             case ABILITY_DODGE_MASTER:


### PR DESCRIPTION
Currently, dx introduced a bug where the final badge you equip would be counted as being equipped n+1 times, where n is the number of empty slots. This is because `badgeMoveID` doesn't get reset between loop iterations if `badgeItemID == ITEM_NONE`

